### PR TITLE
Added configurable merge setting

### DIFF
--- a/Model/Behavior/SerializableBehavior.php
+++ b/Model/Behavior/SerializableBehavior.php
@@ -76,10 +76,14 @@ class SerializableBehavior extends ModelBehavior {
 		}
 		foreach ($this->config[$Model->alias]['fields'] as $field) {
 			if (isset($Model->data[$Model->alias][$field])) {
-				if($currentData) $Model->data[$Model->alias][$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$Model->alias][$field]);
+				if ($currentData) {
+					$Model->data[$Model->alias][$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$Model->alias][$field]);
+				}
 				$Model->data[$Model->alias][$field] = $this->_serialize($Model->alias, $Model->data[$Model->alias][$field]);
 			} elseif (isset($Model->data[$field])) {
-				if($currentData) $Model->data[$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$field]);
+				if ($currentData) {
+					$Model->data[$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$field]);
+				}
 				$Model->data[$field] = $this->_serialize($Model->alias, $Model->data[$field]);
 			}
 		}

--- a/Model/Behavior/SerializableBehavior.php
+++ b/Model/Behavior/SerializableBehavior.php
@@ -65,12 +65,12 @@ class SerializableBehavior extends ModelBehavior {
 	 */
 	public function beforeSave(Model $Model, $options = array()) {
 		$currentData = false;
-		if($this->config[$Model->alias]['merge']){
+		if ($this->config[$Model->alias]['merge']) {
 			$Model->recursive = -1;
 			$currentData = $Model->find('first',
 				array(
 					'conditions' => array($Model->primaryKey => (isset($Model->data[$Model->alias][$Model->primaryKey]) ? $Model->data[$Model->alias][$Model->primaryKey] : $Model->data[$Model->primaryKey])),
-				    'fields' => $this->config[$Model->alias]['fields']
+					'fields' => $this->config[$Model->alias]['fields']
 				)
 			);
 		}

--- a/Model/Behavior/SerializableBehavior.php
+++ b/Model/Behavior/SerializableBehavior.php
@@ -65,7 +65,7 @@ class SerializableBehavior extends ModelBehavior {
 	 */
 	public function beforeSave(Model $Model, $options = array()) {
 		$currentData = false;
-		if ($this->config[$Model->alias]['merge']) {
+		if ($this->config[$Model->alias]['merge'] && (isset($Model->data[$Model->alias][$Model->primaryKey]) || isset($Model->data[$Model->primaryKey]))) {
 			$Model->recursive = -1;
 			$currentData = $Model->find('first',
 				array(
@@ -77,12 +77,12 @@ class SerializableBehavior extends ModelBehavior {
 		foreach ($this->config[$Model->alias]['fields'] as $field) {
 			if (isset($Model->data[$Model->alias][$field])) {
 				if ($currentData) {
-					$Model->data[$Model->alias][$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$Model->alias][$field]);
+					$Model->data[$Model->alias][$field] = array_replace_recursive((array)$currentData[$Model->alias][$field], (array)$Model->data[$Model->alias][$field]);
 				}
 				$Model->data[$Model->alias][$field] = $this->_serialize($Model->alias, $Model->data[$Model->alias][$field]);
 			} elseif (isset($Model->data[$field])) {
 				if ($currentData) {
-					$Model->data[$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$field]);
+					$Model->data[$field] = array_replace_recursive($currentData[$Model->alias][$field], $Model->data[$field]);
 				}
 				$Model->data[$field] = $this->_serialize($Model->alias, $Model->data[$field]);
 			}

--- a/Model/Behavior/SerializableBehavior.php
+++ b/Model/Behavior/SerializableBehavior.php
@@ -33,7 +33,8 @@ class SerializableBehavior extends ModelBehavior {
 			'fields' => array(),
 			'serialize' => 'serialize',
 			'unserialize' => 'unserialize',
-			'aliases' => array()
+			'aliases' => array(),
+			'merge' => false
 		);
 	}
 
@@ -63,10 +64,22 @@ class SerializableBehavior extends ModelBehavior {
 	 * @return boolean True
 	 */
 	public function beforeSave(Model $Model, $options = array()) {
+		$currentData = false;
+		if($this->config[$Model->alias]['merge']){
+			$Model->recursive = -1;
+			$currentData = $Model->find('first',
+				array(
+					'conditions' => array($Model->primaryKey => (isset($Model->data[$Model->alias][$Model->primaryKey]) ? $Model->data[$Model->alias][$Model->primaryKey] : $Model->data[$Model->primaryKey])),
+				    'fields' => $this->config[$Model->alias]['fields']
+				)
+			);
+		}
 		foreach ($this->config[$Model->alias]['fields'] as $field) {
 			if (isset($Model->data[$Model->alias][$field])) {
+				if($currentData) $Model->data[$Model->alias][$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$Model->alias][$field]);
 				$Model->data[$Model->alias][$field] = $this->_serialize($Model->alias, $Model->data[$Model->alias][$field]);
 			} elseif (isset($Model->data[$field])) {
+				if($currentData) $Model->data[$field] = array_merge($currentData[$Model->alias][$field], $Model->data[$field]);
 				$Model->data[$field] = $this->_serialize($Model->alias, $Model->data[$field]);
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Attach behaviour to model:
 	        'fields' => <array of field names>,
 	        'serialize' => <valid callable>, // optional
 	        'unserialize' => <valid callable> // optional
+	        'merge' => true // optional
 	      )
 	);
 
 By default serialization uses function `serialize`, unserialization - `unserialize`
+Merging is off by default, turning it on will do a recursive merge on existing records so you can add data without replacing the entire serialized object.
 
 ## Advanced usage
 

--- a/Test/Case/Model/Behavior/SerializableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/SerializableBehaviorTest.php
@@ -126,7 +126,7 @@ class SerializableBehaviorTest extends CakeTestCase {
 	/**
 	 * Test merging
 	 */
-	public function testMerge(){
+	public function testMerge() {
 		$field1 = array(
 			array(
 				'somedata' => array(

--- a/Test/Case/Model/Behavior/SerializableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/SerializableBehaviorTest.php
@@ -123,4 +123,40 @@ class SerializableBehaviorTest extends CakeTestCase {
 		$this->assertEqual($data, $storedData);
 	}
 
+	/**
+	 * Test merging
+	 */
+	public function testMerge(){
+		$field1 = array(
+			array(
+				'somedata' => array(
+					'k' => 1
+				)
+			)
+		);
+		$field1merge = array(
+			array(
+				'moredata' => array(
+					'm' => 2
+				)
+			)
+		);
+
+		$Model = ClassRegistry::init('SerializableSimpleTestModel');
+		$Model->Behaviors->load('Serializable.Serializable', array('merge' => true, 'fields' => array('field1', 'field2')));
+		$success = $Model->save(compact('field1'));
+
+		$this->assertTrue((bool)$success);
+		$data = $Model->read(array('field1', 'field2'), $Model->id);
+		$this->assertSame($field1, $data[$Model->alias]['field1']);
+
+		$success = $Model->save(array('id' => $Model->id, 'field1' => $field1merge));
+		$this->assertTrue((bool)$success);
+
+		$data = $Model->read(array('field1'), $Model->id);
+		$this->assertSame(array_replace_recursive($field1, $field1merge), $data[$Model->alias]['field1']);
+
+		$Model->Behaviors->load('Serializable.Serializable', array('merge' => false));
+	}
+
 }


### PR DESCRIPTION
Added a boolean setting merge which on true merges any existing serialised data with new serialised data. Specifically useful for imports which need to overwrite some data but not touch other data in the serialised field.

I have written no tests or documentation for this as we use this internally but figured it might be a nice addition to the plugin.
